### PR TITLE
Additional print cols for connection phase, expiry

### DIFF
--- a/operator/src/oauth_connection/resource.rs
+++ b/operator/src/oauth_connection/resource.rs
@@ -10,6 +10,8 @@ use serde::{Deserialize, Serialize};
     version = "v1",
     kind = "OAuthConnection",
     status = "OAuthConnectionStatus",
+    printcolumn = r#"{"name":"Status", "type":"string", "description":"current connection status", "jsonPath":".status.phase"}"#,
+    printcolumn = r#"{"name":"Expiry", "type":"string", "description":"token expiry", "jsonPath":".status.expires_at"}"#,
     namespaced
 )]
 #[serde(rename_all = "camelCase")]


### PR DESCRIPTION
Added Additional Printer Columns to OAuthConnection resource GET to display current connection phase status and token expiry date if token has been issued

```
kubectl get oauthconnection -o wide -A
NAMESPACE   NAME      STATUS         EXPIRY
default     discord   Disconnected   <no value>
```

Closes #12

Signed-off-by: Nitish Malhotra <nitish.malhotra@gmail.com>